### PR TITLE
Provide an Accept header with all requests

### DIFF
--- a/lib/searchyll/indexer.rb
+++ b/lib/searchyll/indexer.rb
@@ -98,6 +98,7 @@ module Searchyll
     def http_request(klass, path)
       req = klass.new(path)
       req.content_type = 'application/json'
+      req['Accept']    = 'application/json'
       req.basic_auth(uri.user, uri.password)
       req
     end


### PR DESCRIPTION
For v5 compat, which (rightfully) no longer uses the content-type header for this purpose.

Fixes #17.