### PR TITLE
Use PUT instead of POST

### DIFF
--- a/lib/searchyll/indexer.rb
+++ b/lib/searchyll/indexer.rb
@@ -49,7 +49,7 @@ module Searchyll
 
     # Prepare our indexing run by creating a new index.
     def prepare_index
-      create_index = http_post("/#{elasticsearch_index_name}")
+      create_index = http_put("/#{elasticsearch_index_name}")
       create_index.body = {
         index: {
           number_of_shards:   configuration.elasticsearch_number_of_shards,


### PR DESCRIPTION
Not sure what behaviour before Elasticsearch 5.0 was.

Now
```json
POST /some_index
{
  "index": {
    "number_of_shards":   5,
    "number_of_replicas": 0,
    "refresh_interval":   -1
  }
}
```

returns
```
No handler found for uri [/some_index] and method [POST]
```


The proper http request method is PUT
https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-create-index.html