### PR TITLE
Robsears patch 2

### DIFF
--- a/lib/searchyll/configuration.rb
+++ b/lib/searchyll/configuration.rb
@@ -8,8 +8,7 @@ module Searchyll
     # Determine a URL for the cluster, or fail with error
     def elasticsearch_url
       ENV['BONSAI_URL'] || ENV['ELASTICSEARCH_URL'] ||
-        ((site.config||{})['elasticsearch']||{})['url'] ||
-        raise(ArgumentError, "No Elasticsearch URL present, skipping indexing")
+        ((site.config||{})['elasticsearch']||{})['url'].to_s
     end
 
     # Getter for the number of primary shards

--- a/lib/searchyll/generator.rb
+++ b/lib/searchyll/generator.rb
@@ -14,6 +14,12 @@ module Searchyll
       # Gather the configuration options
       configuration = Configuration.new(site)
 
+      # Don't do anything if the Elasticsearch URL is missing
+      if configuration.elasticsearch_url.empty?
+        puts "No Elasticsearch URL present, skipping indexing"
+        return
+      end
+
       # Prepare the indexer
       indexer = Searchyll::Indexer.new(configuration)
       indexer.start

--- a/lib/searchyll/version.rb
+++ b/lib/searchyll/version.rb
@@ -1,3 +1,3 @@
 module Searchyll
-  VERSION = "0.10.0"
+  VERSION = "0.10.1"
 end


### PR DESCRIPTION
We should not be raising an exception when reading configuration settings. Also, raising the exception here breaks site generation. We should just print a message explaining the problem and then let Jekyll move on.