### PR TITLE
Remove unnecessary elasticsearch-ruby dependency.

### DIFF
--- a/searchyll.gemspec
+++ b/searchyll.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "guard-rspec"
 
   spec.add_dependency "jekyll", ">= 3.0"
-  spec.add_dependency "elasticsearch-ruby"
   spec.add_dependency "nokogiri"
 
 end


### PR DESCRIPTION
We included the elasticsearch-ruby library quite a while ago, but have never used it (we manually create our API endpoint calls). This PR removes the unnecessary gem.