### PR TITLE
Fix page indexing using the correct property `title` instead of `name`.

### DIFF
--- a/lib/searchyll.rb
+++ b/lib/searchyll.rb
@@ -35,7 +35,7 @@ begin
 
     if (indexer = indexers[page.site])
       indexer << page.data.merge({
-        id:     page.name,
+        id:     page.title,
         url:    page.url,
         text:   nokogiri_doc.xpath("//article//text()").to_s.gsub(/\s+/, " ")
       })


### PR DESCRIPTION
This resolves specifically the following error: `jekyll 3.8.2 | Error:  undefined method 'name' for #<Jekyll::Document`.