### PR TITLE
Write Elasticsearch API errors to $stderr

### DIFF
--- a/lib/searchyll/indexer.rb
+++ b/lib/searchyll/indexer.rb
@@ -237,7 +237,11 @@ module Searchyll
           } }
         ]
       }.to_json
-      http.request(update_aliases)
+      res = http.request(update_aliases)
+      if !res.kind_of?(Net::HTTPSuccess)
+        $stderr.puts "Elasticsearch returned an error when updating aliases: " + res.message + " " + res.body
+        exit
+      end
     end
 
     # delete old indices after a successful reindexing run

--- a/lib/searchyll/indexer.rb
+++ b/lib/searchyll/indexer.rb
@@ -164,7 +164,7 @@ module Searchyll
         [{ index: {} }.to_json, doc.to_json].join("\n")
       end.join("\n") + "\n"
       res = http.request(bulk_insert)
-      $stderr.puts "Elasticsearch returned an error when performing bulk insert: " + res.message if !res.kind_of?(Net::HTTPSuccess)
+      $stderr.puts "Elasticsearch returned an error when performing bulk insert: " + res.message + " " + res.body if !res.kind_of?(Net::HTTPSuccess)
     end
 
     # Fetch a batch of documents from the queue. Returns a maximum of BATCH_SIZE

--- a/lib/searchyll/indexer.rb
+++ b/lib/searchyll/indexer.rb
@@ -164,7 +164,10 @@ module Searchyll
         [{ index: {} }.to_json, doc.to_json].join("\n")
       end.join("\n") + "\n"
       res = http.request(bulk_insert)
-      $stderr.puts "Elasticsearch returned an error when performing bulk insert: " + res.message + " " + res.body if !res.kind_of?(Net::HTTPSuccess)
+      if !res.kind_of?(Net::HTTPSuccess)
+        $stderr.puts "Elasticsearch returned an error when performing bulk insert: " + res.message + " " + res.body
+        exit
+      end
     end
 
     # Fetch a batch of documents from the queue. Returns a maximum of BATCH_SIZE

--- a/lib/searchyll/indexer.rb
+++ b/lib/searchyll/indexer.rb
@@ -163,7 +163,8 @@ module Searchyll
       bulk_insert.body = batch.map do |doc|
         [{ index: {} }.to_json, doc.to_json].join("\n")
       end.join("\n") + "\n"
-      http.request(bulk_insert)
+      res = http.request(bulk_insert)
+      $stderr.puts "Elasticsearch returned an error when performing bulk insert: " + res.message if !res.kind_of?(Net::HTTPSuccess)
     end
 
     # Fetch a batch of documents from the queue. Returns a maximum of BATCH_SIZE


### PR DESCRIPTION
As of now, Searchyll gives no feedback about success or failure of API requests. I'm getting a "Bad Request" from a proxied Elasticsearch, and it took me a while before realizing it because the Searchyll job seemed to succeed.
This code prints the error to the console and exits the build, so that the error can be investigated.