### PR TITLE
Prevent sending duplicate keys to Elasticsearch

### DIFF
--- a/lib/searchyll.rb
+++ b/lib/searchyll.rb
@@ -38,9 +38,9 @@ begin
 
     if (indexer = indexers[page.site])
       indexer << ({
-        "id":     page.name,
-        "url":    page.url,
-        "text":   nokogiri_doc.xpath("//article//text()").to_s.gsub(/\s+/, " ")
+        "id"   => page.name,
+        "url"  => page.url,
+        "text" => nokogiri_doc.xpath("//article//text()").to_s.gsub(/\s+/, " ")
       }).merge(page.data)
     end
   end
@@ -54,9 +54,9 @@ begin
 
     if (indexer = indexers[document.site])
       indexer << ({
-        "id":     document.id,
-        "url":    document.url,
-        "text":   nokogiri_doc.xpath("//article//text()").to_s.gsub(/\s+/, " ")
+        "id"   =>  document.id,
+        "url"  =>  document.url,
+        "text" =>  nokogiri_doc.xpath("//article//text()").to_s.gsub(/\s+/, " ")
       }).merge(document.data)
     end
   end

--- a/lib/searchyll.rb
+++ b/lib/searchyll.rb
@@ -37,11 +37,11 @@ begin
     # puts %(        indexing page #{page.url})
 
     if (indexer = indexers[page.site])
-      indexer << page.data.merge({
-        id:     page.name,
-        url:    page.url,
-        text:   nokogiri_doc.xpath("//article//text()").to_s.gsub(/\s+/, " ")
-      })
+      indexer << ({
+        "id":     page.name,
+        "url":    page.url,
+        "text":   nokogiri_doc.xpath("//article//text()").to_s.gsub(/\s+/, " ")
+      }).merge(page.data)
     end
   end
 
@@ -53,11 +53,11 @@ begin
     # puts %(        indexing document #{document.url})
 
     if (indexer = indexers[document.site])
-      indexer << document.data.merge({
-        id:     document.id,
-        url:    document.url,
-        text:   nokogiri_doc.xpath("//article//text()").to_s.gsub(/\s+/, " ")
-      })
+      indexer << ({
+        "id":     document.id,
+        "url":    document.url,
+        "text":   nokogiri_doc.xpath("//article//text()").to_s.gsub(/\s+/, " ")
+      }).merge(document.data)
     end
   end
 


### PR DESCRIPTION
Some of my pages had a `text` variable in the frontmatter:

```yaml
title: My title
text: >
  blah blah blah
order: 5
lang: it
```

However Searchyll appends one more `text` key to the document:

https://github.com/omc/searchyll/blob/e601fea641979982d12e8210aea6699434b31840/lib/searchyll.rb#L56-L59

Such `text` key is a symbol (`:text`), so the hash supplied to `indexer` contains both. When converted to JSON, they result in a duplicate key:

```json
{
	"title": "My title",
	"text": "blah blah blah\n",
	"order": 5,
	"lang": "it",
	"id": "/faqs/it/5",
	"url": "/faqs/it/5.yml",
	"text": ""
}
```

Elasticsearch will complain about this and reject the insertion:

```
[2019-02-01T22:19:45,713][DEBUG][o.e.a.b.TransportShardBulkAction] [NODE-1] [jekyll-20190201231940][0] failed to execute bulk item (index) index ...
[...]
Caused by: com.fasterxml.jackson.core.JsonParseException: Duplicate field 'text'
```

This patch will prevent sending duplicate keys, by giving precedence to the variables explicitely set by user in the frontmatter.