### PR TITLE
Gracefully support incomplete settings

### DIFF
--- a/lib/searchyll/configuration.rb
+++ b/lib/searchyll/configuration.rb
@@ -84,18 +84,15 @@ module Searchyll
     end
 
     def elasticsearch_settings
-      shards = site.config['elasticsearch']['number_of_shards'] || 1
-      replicas = site.config['elasticsearch']['number_of_replicas'] || 1
-      read_yaml(elasticsearch_settings_path, {
-        'index' => {
-          'number_of_shards'   => shards,
-          'number_of_replicas' => replicas,
-          'refresh_interval'   => -1
-        }
-      })
+      settings = read_yaml(elasticsearch_settings_path)
+      settings['index'] ||= {}
+      settings['index']['number_of_shards']   ||= site.config['elasticsearch']['number_of_shards'] || 1
+      settings['index']['number_of_replicas'] ||= site.config['elasticsearch']['number_of_replicas'] || 1
+      settings['index']['refresh_interval']   ||= -1
+      settings
     end
 
-    def read_yaml(path, default)
+    def read_yaml(path, default = {})
       if path
         joined_path = File.join(@site.source, path)
         expanded_path = File.expand_path(joined_path)


### PR DESCRIPTION
I didn't put the following lines in my custom settings file:

```yaml
index:
  number_of_shards: 1
  number_of_replicas: 0
```

and I expected everything to work because such variables are also set in the main Jekyll configuration files. However I got a hard Ruby error, because `elasticsearch_number_of_replicas()` expects to read one of those values.
This PR will gracefully handle an incomplete settings file by pulling the main configuration values.