### PR TITLE
Better compliance with Elasticsearch API

### DIFF
--- a/lib/searchyll/indexer.rb
+++ b/lib/searchyll/indexer.rb
@@ -164,7 +164,7 @@ module Searchyll
       bulk_insert.content_type = 'application/x-ndjson'
       bulk_insert.body = batch.map do |doc|
         [{ index: {} }.to_json, doc.to_json].join("\n")
-      end.force_encoding('ascii-8bit').join("\n") + "\n"
+      end.join("\n").force_encoding('ascii-8bit') + "\n"
       http.request(bulk_insert)
     end
 

--- a/lib/searchyll/indexer.rb
+++ b/lib/searchyll/indexer.rb
@@ -159,10 +159,12 @@ module Searchyll
     # using its Bulk Update API.
     # https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
     def es_bulk_insert!(http, batch)
+      return if batch.empty?
       bulk_insert = http_post("/#{elasticsearch_index_name}/#{configuration.elasticsearch_default_type}/_bulk")
+      bulk_insert.content_type = 'application/x-ndjson'
       bulk_insert.body = batch.map do |doc|
         [{ index: {} }.to_json, doc.to_json].join("\n")
-      end.join("\n") + "\n"
+      end.force_encoding('ascii-8bit').join("\n") + "\n"
       http.request(bulk_insert)
     end
 


### PR DESCRIPTION
Documentation for [Elasticsearch Bulk API](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html) says that requests should carry the `Content-Type: application/x-ndjson` header.

I also observed that Elasticsearch was rejecting some of my updates with a `The bulk request must be terminated by a newline` error, which was caused by Searchyll not sending data in binary mode. Adding `.force_encoding('ascii-8bit')` solved the issue for me.

I also noticed that Searchyll was sending empty requests to the Bulk API, which caused an error by Elasticsearch. This PR prevents such empty requests.