### PR TITLE
Add ability to ignore certain paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ elasticsearch:
   default_type: "post"              # Optional. Default type is "post".
   custom_settings: _es_settings.yml # Optional. No default. Relative to your src folder
   custom_mappings: _es_mappings.yml # Optional. No default. Relative to your src folder
+  ignore:                           # Optional. No default.
+    - /news/*
 ```
 
 ### Custom Settings File Example

--- a/lib/searchyll/configuration.rb
+++ b/lib/searchyll/configuration.rb
@@ -69,6 +69,11 @@ module Searchyll
       site.config['elasticsearch']['default_type'] || 'post'
     end
 
+    # Getter for the ignore regex
+    def elasticsearch_ignore
+      site.config['elasticsearch']['ignore'] || []
+    end
+
     # Getter for es mapping
     def elasticsearch_mapping_path
       site.config['elasticsearch']['custom_mappings']

--- a/lib/searchyll/indexer.rb
+++ b/lib/searchyll/indexer.rb
@@ -20,6 +20,7 @@ module Searchyll
     attr_accessor :timestamp
     attr_accessor :uri
     attr_accessor :working
+    attr_accessor :ignore_regex
 
     # Initialize a basic indexer, with a Jekyll site configuration, waiting
     # to be supplied with documents for indexing.
@@ -30,11 +31,19 @@ module Searchyll
       self.working       = true
       self.timestamp     = Time.now
       self.batch_size    = BATCH_SIZE
+      
+      # Compute a regex for detecting paths to ignore
+      escaped = (configuration.elasticsearch_ignore.map {|i| Regexp.escape(i).gsub('\*','.+?')}).join('|')
+      self.ignore_regex = Regexp.new "^(#{escaped})$", Regexp::IGNORECASE
     end
 
     # Public: Add new documents for batch indexing.
     def <<(doc)
-      queue << doc
+      if doc['url'] =~ self.ignore_regex
+        #puts %(        ...ignoring)
+      else
+        queue << doc
+      end
     end
 
     # Public: start the indexer and wait for documents to index.


### PR DESCRIPTION
This PR introduces a configuration option that allows to ignore certain paths. Wildcards supported:

```yaml
elasticsearch:
  url: "http://localhost:9200/"     # Required. Supports auth and SSL: https://user:pass@someurl.com
                                    # Can also read URLs stored in environment variable named
                                    # BONSAI_URL and ELASTICSEARCH_URL.
  number_of_shards: 1               # Optional. Default is 1 primary shard.
  number_of_replicas: 1             # Optional. Default is 1 replica.
  index_name: "jekyll"              # Optional. Default is "jekyll".
  default_type: "post"              # Optional. Default type is "post".
  custom_settings: _es_settings.yml # Optional. No default. Relative to your src folder
  custom_mappings: _es_mappings.yml # Optional. No default. Relative to your src folder
  ignore:                           # Optional. No default.
    - /news/*
```