### PR TITLE
Add feature - environments support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ elasticsearch:
   default_type: "post"              # Optional. Default type is "post".
   custom_settings: _es_settings.yml # Optional. No default. Relative to your src folder
   custom_mappings: _es_mappings.yml # Optional. No default. Relative to your src folder
-  production_only: false            # Optional. Defaults to false.
+  environments:                     # Optional. Set environments where Searchyll should run
+    - 'production'                  # Default runs on all environment if empty
+    - 'development'                 # If set will only run in speccified environments
 ```
 
 ### Custom Settings File Example

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ elasticsearch:
   default_type: "post"              # Optional. Default type is "post".
   custom_settings: _es_settings.yml # Optional. No default. Relative to your src folder
   custom_mappings: _es_mappings.yml # Optional. No default. Relative to your src folder
+  production_only: false            # Optional. Defaults to false.
 ```
 
 ### Custom Settings File Example
@@ -69,4 +70,4 @@ prompt that will allow you to experiment.
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at
-https://github.com/omc/searchyll
+<https://github.com/omc/searchyll>

--- a/lib/searchyll.rb
+++ b/lib/searchyll.rb
@@ -13,7 +13,7 @@ begin
     config = Searchyll::Configuration.new(site)
     if config.valid?
       # return if we should only run in production
-      return if config.elasticsearch_production_only?
+      return unless config.elasticsearch_production_only?
       puts "setting up indexer hook"
       indexers[site] = Searchyll::Indexer.new(config)
       indexers[site].start

--- a/lib/searchyll.rb
+++ b/lib/searchyll.rb
@@ -12,6 +12,7 @@ begin
   Jekyll::Hooks.register(:site, :pre_render) do |site|
     config = Searchyll::Configuration.new(site)
     if config.valid?
+      # return if we should only run in production
       return if config.elasticsearch_production_only
       puts "setting up indexer hook"
       indexers[site] = Searchyll::Indexer.new(config)
@@ -32,6 +33,8 @@ begin
 
   # gets random pages like your home page
   Jekyll::Hooks.register :pages, :post_render do |page|
+    # return if we should only run in production
+    return if config.elasticsearch_production_only
     # strip html
     nokogiri_doc = Nokogiri::HTML(page.output)
 
@@ -48,6 +51,8 @@ begin
 
   # gets both posts and collections
   Jekyll::Hooks.register :documents, :post_render do |document|
+    # return if we should only run in production
+    return if config.elasticsearch_production_only
     # strip html
     nokogiri_doc = Nokogiri::HTML(document.output)
 

--- a/lib/searchyll.rb
+++ b/lib/searchyll.rb
@@ -13,12 +13,12 @@ begin
     config = Searchyll::Configuration.new(site)
     if config.valid?
       # return if we should only run in production
-      unless config.elasticsearch_production_only?
+      if config.should_execute_in_current_environment?
         puts "setting up indexer hook"
         indexers[site] = Searchyll::Indexer.new(config)
         indexers[site].start
       else
-        puts "Not running outside of produciton"
+        puts "Not running outside of production"
       end
     else
       puts 'Invalid Elasticsearch configuration provided, skipping indexing...'

--- a/lib/searchyll.rb
+++ b/lib/searchyll.rb
@@ -12,7 +12,7 @@ begin
   Jekyll::Hooks.register(:site, :pre_render) do |site|
     config = Searchyll::Configuration.new(site)
     if config.valid?
-      return if site.config['environment'] == "production" && site.config['elasticsearch']['production_only'] == true
+      return if config.elasticsearch_production_only
       puts "setting up indexer hook"
       indexers[site] = Searchyll::Indexer.new(config)
       indexers[site].start

--- a/lib/searchyll.rb
+++ b/lib/searchyll.rb
@@ -12,6 +12,7 @@ begin
   Jekyll::Hooks.register(:site, :pre_render) do |site|
     config = Searchyll::Configuration.new(site)
     if config.valid?
+      return if site.config['environment'] == "production" && site.config['elasticsearch']['production_only'] == true
       puts "setting up indexer hook"
       indexers[site] = Searchyll::Indexer.new(config)
       indexers[site].start

--- a/lib/searchyll.rb
+++ b/lib/searchyll.rb
@@ -13,10 +13,13 @@ begin
     config = Searchyll::Configuration.new(site)
     if config.valid?
       # return if we should only run in production
-      return unless config.elasticsearch_production_only?
-      puts "setting up indexer hook"
-      indexers[site] = Searchyll::Indexer.new(config)
-      indexers[site].start
+      unless config.elasticsearch_production_only?
+        puts "setting up indexer hook"
+        indexers[site] = Searchyll::Indexer.new(config)
+        indexers[site].start
+      else
+        puts "Not running outside of produciton"
+      end
     else
       puts 'Invalid Elasticsearch configuration provided, skipping indexing...'
       config.reasons.each do |r|

--- a/lib/searchyll.rb
+++ b/lib/searchyll.rb
@@ -33,14 +33,11 @@ begin
 
   # gets random pages like your home page
   Jekyll::Hooks.register :pages, :post_render do |page|
-    # return if we should only run in production
-    return if config.elasticsearch_production_only
-    # strip html
-    nokogiri_doc = Nokogiri::HTML(page.output)
-
-    # puts %(        indexing page #{page.url})
-
     if (indexer = indexers[page.site])
+      # strip html
+      nokogiri_doc = Nokogiri::HTML(page.output)
+  
+      # puts %(        indexing page #{page.url})
       indexer << ({
         "id"   => page.name,
         "url"  => page.url,
@@ -51,14 +48,11 @@ begin
 
   # gets both posts and collections
   Jekyll::Hooks.register :documents, :post_render do |document|
-    # return if we should only run in production
-    return if config.elasticsearch_production_only
-    # strip html
-    nokogiri_doc = Nokogiri::HTML(document.output)
-
-    # puts %(        indexing document #{document.url})
-
     if (indexer = indexers[document.site])
+      # strip html
+      nokogiri_doc = Nokogiri::HTML(document.output)
+      # puts %(        indexing document #{document.url})
+
       indexer << ({
         "id"   =>  document.id,
         "url"  =>  document.url,

--- a/lib/searchyll.rb
+++ b/lib/searchyll.rb
@@ -13,7 +13,7 @@ begin
     config = Searchyll::Configuration.new(site)
     if config.valid?
       # return if we should only run in production
-      return if config.elasticsearch_production_only
+      return if config.elasticsearch_production_only?
       puts "setting up indexer hook"
       indexers[site] = Searchyll::Indexer.new(config)
       indexers[site].start

--- a/lib/searchyll/configuration.rb
+++ b/lib/searchyll/configuration.rb
@@ -79,6 +79,10 @@ module Searchyll
       site.config['elasticsearch']['custom_settings']
     end
 
+    def elasticsearch_production_only
+      site.config['environment'] == "production" && site.config['elasticsearch']['production_only'] == true
+    end
+
     def elasticsearch_mapping
         read_yaml(elasticsearch_mapping_path, nil)
     end

--- a/lib/searchyll/configuration.rb
+++ b/lib/searchyll/configuration.rb
@@ -80,7 +80,12 @@ module Searchyll
     end
 
     def should_execute_in_current_environment?
-      site.config['elasticsearch']['production_only'] == true || site.config['environment'] == "production"
+      settings = site.config['elasticsearch']
+
+      return true if settings['environments'].nil?
+      return true unless settings['environments'].is_a?(Array)
+
+      site.config['elasticsearch']['environments'].include? site.config['environment']
     end
 
     def elasticsearch_mapping

--- a/lib/searchyll/configuration.rb
+++ b/lib/searchyll/configuration.rb
@@ -79,8 +79,8 @@ module Searchyll
       site.config['elasticsearch']['custom_settings']
     end
 
-    def elasticsearch_production_only?
-      site.config['environment'] == "production" || site.config['elasticsearch']['production_only'] == true
+    def should_execute_in_current_environment?
+      site.config['elasticsearch']['production_only'] == true || site.config['environment'] == "production"
     end
 
     def elasticsearch_mapping

--- a/lib/searchyll/configuration.rb
+++ b/lib/searchyll/configuration.rb
@@ -79,7 +79,7 @@ module Searchyll
       site.config['elasticsearch']['custom_settings']
     end
 
-    def elasticsearch_production_only
+    def elasticsearch_production_only?
       site.config['environment'] == "production" && site.config['elasticsearch']['production_only'] == true
     end
 

--- a/lib/searchyll/configuration.rb
+++ b/lib/searchyll/configuration.rb
@@ -80,7 +80,7 @@ module Searchyll
     end
 
     def elasticsearch_production_only?
-      site.config['environment'] == "production" && site.config['elasticsearch']['production_only'] == true
+      site.config['environment'] == "production" || site.config['elasticsearch']['production_only'] == true
     end
 
     def elasticsearch_mapping

--- a/searchyll.gemspec
+++ b/searchyll.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.10"
+  spec.add_development_dependency "bundler", ">= 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "guard-rspec"

--- a/spec/searchyll/configuration_spec.rb
+++ b/spec/searchyll/configuration_spec.rb
@@ -19,7 +19,7 @@ describe Searchyll::Configuration do
     }
     site = TestSite.new site_config
     conf = Searchyll::Configuration.new site
-    expect(conf.elasticsearch_production_only?).to eq(true)
+    expect(conf.should_execute_in_current_environment?).to eq(true)
   end
 
   it 'is expected to return true when production and flag is set' do
@@ -31,7 +31,7 @@ describe Searchyll::Configuration do
     }
     site = TestSite.new site_config
     conf = Searchyll::Configuration.new site
-    expect(conf.elasticsearch_production_only?).to eq(true)
+    expect(conf.should_execute_in_current_environment?).to eq(true)
   end
 
   it 'is expected to return false when not production and flag is not set' do
@@ -43,7 +43,7 @@ describe Searchyll::Configuration do
     }
     site = TestSite.new site_config
     conf = Searchyll::Configuration.new site
-    expect(conf.elasticsearch_production_only?).to eq(false)
+    expect(conf.should_execute_in_current_environment?).to eq(false)
   end
 
   it 'is expected to return false when not production and flag is set' do
@@ -55,6 +55,6 @@ describe Searchyll::Configuration do
     }
     site = TestSite.new site_config
     conf = Searchyll::Configuration.new site
-    expect(conf.elasticsearch_production_only?).to eq(false)
+    expect(conf.should_execute_in_current_environment?).to eq(false)
   end
 end

--- a/spec/searchyll/configuration_spec.rb
+++ b/spec/searchyll/configuration_spec.rb
@@ -1,0 +1,81 @@
+require File.expand_path('../spec_helper', File.dirname(__FILE__))
+require "jekyll"
+
+describe Searchyll::Configuration do
+
+  it 'is expected to return true when production and flag not set' do
+    site_config = {
+      'environment' => 'production',
+      'elasticsearch' => {
+        'production_only' => false
+      },
+      'source' => __dir__,
+      'destination' => __dir__,
+      'cache_dir' => __dir__,
+      'permalink' => __dir__,
+      'liquid' => {
+        'error_mode' => false
+      }
+    }
+    site = TestSite.new site_config
+    conf = Searchyll::Configuration.new site
+    expect(conf.elasticsearch_production_only?).to eq(true)
+  end
+
+  it 'is expected to return true when production and flag is set' do
+    site_config = {
+      'environment' => 'production',
+      'elasticsearch' => {
+        'production_only' => true
+      },
+      'source' => __dir__,
+      'destination' => __dir__,
+      'cache_dir' => __dir__,
+      'permalink' => __dir__,
+      'liquid' => {
+        'error_mode' => false
+      }
+    }
+    site = TestSite.new site_config
+    conf = Searchyll::Configuration.new site
+    expect(conf.elasticsearch_production_only?).to eq(true)
+  end
+
+  it 'is expected to return false when not production and flag is set' do
+    site_config = {
+      'environment' => 'not_production',
+      'elasticsearch' => {
+        'production_only' => true
+      },
+      'source' => __dir__,
+      'destination' => __dir__,
+      'cache_dir' => __dir__,
+      'permalink' => __dir__,
+      'liquid' => {
+        'error_mode' => false
+      }
+    }
+    site = TestSite.new site_config
+    conf = Searchyll::Configuration.new site
+    expect(conf.elasticsearch_production_only?).to eq(false)
+  end
+
+  it 'is expected to return false when not production and flag is not set' do
+    site_config = {
+      'environment' => 'not_production',
+      'elasticsearch' => {
+        'production_only' => false
+      },
+      'source' => __dir__,
+      'destination' => __dir__,
+      'cache_dir' => __dir__,
+      'permalink' => __dir__,
+      'liquid' => {
+        'error_mode' => false
+      }
+    }
+    site = TestSite.new site_config
+    conf = Searchyll::Configuration.new site
+    expect(conf.elasticsearch_production_only?).to eq(false)
+  end
+end

--- a/spec/searchyll/configuration_spec.rb
+++ b/spec/searchyll/configuration_spec.rb
@@ -43,14 +43,14 @@ describe Searchyll::Configuration do
     }
     site = TestSite.new site_config
     conf = Searchyll::Configuration.new site
-    expect(conf.elasticsearch_production_only?).to eq(true)
+    expect(conf.elasticsearch_production_only?).to eq(false)
   end
 
   it 'is expected to return false when not production and flag is set' do
     site_config = {
       'environment' => 'not_production',
       'elasticsearch' => {
-        'production_only' => false
+        'production_only' => true
       }
     }
     site = TestSite.new site_config

--- a/spec/searchyll/configuration_spec.rb
+++ b/spec/searchyll/configuration_spec.rb
@@ -10,11 +10,10 @@ end
 
 describe Searchyll::Configuration do
 
-  it 'is expected to return true when production and flag not set' do
+  it 'is expected to return true when production no environment spessified' do
     site_config = {
       'environment' => 'production',
       'elasticsearch' => {
-        'production_only' => false
       }
     }
     site = TestSite.new site_config
@@ -22,11 +21,11 @@ describe Searchyll::Configuration do
     expect(conf.should_execute_in_current_environment?).to eq(true)
   end
 
-  it 'is expected to return true when production and flag is set' do
+  it 'is expected to return true when production and environment is nil' do
     site_config = {
       'environment' => 'production',
       'elasticsearch' => {
-        'production_only' => true
+        'environments' => nil
       }
     }
     site = TestSite.new site_config
@@ -34,11 +33,23 @@ describe Searchyll::Configuration do
     expect(conf.should_execute_in_current_environment?).to eq(true)
   end
 
-  it 'is expected to return false when not production and flag is not set' do
+  it 'is expected to return true when production and environment is not a array' do
     site_config = {
-      'environment' => 'not_production',
+      'environment' => 'production',
       'elasticsearch' => {
-        'production_only' => false
+        'environments' => true
+      }
+    }
+    site = TestSite.new site_config
+    conf = Searchyll::Configuration.new site
+    expect(conf.should_execute_in_current_environment?).to eq(true)
+  end
+
+  it 'is expected to return false when production and different environment spessified' do
+    site_config = {
+      'environment' => 'production',
+      'elasticsearch' => {
+        'environments' => ['dev']
       }
     }
     site = TestSite.new site_config
@@ -46,15 +57,16 @@ describe Searchyll::Configuration do
     expect(conf.should_execute_in_current_environment?).to eq(false)
   end
 
-  it 'is expected to return false when not production and flag is set' do
+  it 'is expected to return true when production and several environment spessified' do
     site_config = {
-      'environment' => 'not_production',
+      'environment' => 'production',
       'elasticsearch' => {
-        'production_only' => true
+        'environments' => ['dev', 'test', 'stage', 'production']
       }
     }
     site = TestSite.new site_config
     conf = Searchyll::Configuration.new site
-    expect(conf.should_execute_in_current_environment?).to eq(false)
+    expect(conf.should_execute_in_current_environment?).to eq(true)
   end
+  
 end

--- a/spec/searchyll/configuration_spec.rb
+++ b/spec/searchyll/configuration_spec.rb
@@ -1,6 +1,13 @@
 require File.expand_path('../spec_helper', File.dirname(__FILE__))
 require "jekyll"
 
+class TestSite
+  attr_accessor :config
+  def initialize(config)
+    @config = config
+  end
+end
+
 describe Searchyll::Configuration do
 
   it 'is expected to return true when production and flag not set' do
@@ -8,13 +15,6 @@ describe Searchyll::Configuration do
       'environment' => 'production',
       'elasticsearch' => {
         'production_only' => false
-      },
-      'source' => __dir__,
-      'destination' => __dir__,
-      'cache_dir' => __dir__,
-      'permalink' => __dir__,
-      'liquid' => {
-        'error_mode' => false
       }
     }
     site = TestSite.new site_config
@@ -27,13 +27,18 @@ describe Searchyll::Configuration do
       'environment' => 'production',
       'elasticsearch' => {
         'production_only' => true
-      },
-      'source' => __dir__,
-      'destination' => __dir__,
-      'cache_dir' => __dir__,
-      'permalink' => __dir__,
-      'liquid' => {
-        'error_mode' => false
+      }
+    }
+    site = TestSite.new site_config
+    conf = Searchyll::Configuration.new site
+    expect(conf.elasticsearch_production_only?).to eq(true)
+  end
+
+  it 'is expected to return false when not production and flag is not set' do
+    site_config = {
+      'environment' => 'not_production',
+      'elasticsearch' => {
+        'production_only' => false
       }
     }
     site = TestSite.new site_config
@@ -45,33 +50,7 @@ describe Searchyll::Configuration do
     site_config = {
       'environment' => 'not_production',
       'elasticsearch' => {
-        'production_only' => true
-      },
-      'source' => __dir__,
-      'destination' => __dir__,
-      'cache_dir' => __dir__,
-      'permalink' => __dir__,
-      'liquid' => {
-        'error_mode' => false
-      }
-    }
-    site = TestSite.new site_config
-    conf = Searchyll::Configuration.new site
-    expect(conf.elasticsearch_production_only?).to eq(false)
-  end
-
-  it 'is expected to return false when not production and flag is not set' do
-    site_config = {
-      'environment' => 'not_production',
-      'elasticsearch' => {
         'production_only' => false
-      },
-      'source' => __dir__,
-      'destination' => __dir__,
-      'cache_dir' => __dir__,
-      'permalink' => __dir__,
-      'liquid' => {
-        'error_mode' => false
       }
     }
     site = TestSite.new site_config


### PR DESCRIPTION
Hello! I've started using seachyll and I wanted it to support not running in all environments to make configuration and setup easier for myself so I added support for an array key named `environments` so users can disable pushing to ElasticSearch when running in speccified environments.

Many thanks to @asbjornu for help and comments to this.